### PR TITLE
Bugfix - Bottom tab bar issue on Android

### DIFF
--- a/screens/DiaryScreen.js
+++ b/screens/DiaryScreen.js
@@ -84,6 +84,7 @@ function DiaryScreen() {
             paddingTop: scale(10),
           },
         }}
+        lazy
         style={{ backgroundColor: theme.colors.primary }}
       >
         <Tab.Screen name="Entries" component={DiaryEntriesScreen} />


### PR DESCRIPTION
### What does this PR do?

- Lazily loaded tab screens on the sleep tab.

### Context

- https://www.notion.so/CBT-i-App-Hub-Dozy-c71a8c25d3ec407cbffcd42bd35286f7?p=edb2f07d597046cc819fb2780a4d3cef
- https://threads.com/34406352075?share=d23b33ad-e8b4-4be1-bbb2-cf465f5f6fb6

### QA checklist

<!-- Some general requirements for QA. If your PR only touches a small self-contained part of the codebase, feel free to only test related components. The depth of testing should match the invasiveness of the PR - add checks accordingly -->

- [x] Pressing the bottom buttons are responsive at the first time to start the app on Android.
