### PR TITLE
Feature - Enable users to tap outside time picker to dismiss it on iOS (currently need to hit Done)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-native-safe-area-context": "3.2.0"
   },
   "dependencies": {
-    "@draftbit/ui": "npm:@samstowers/draftbit-ui",
+    "@draftbit/ui": "npm:@fancydevpro/draftbit-ui@39.7.1-patch-date-picker-3",
     "@expo-google-fonts/rubik": "^0.1.0",
     "@expo/vector-icons": "^12.0.0",
     "@react-native-community/datetimepicker": "3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2831,10 +2831,10 @@
     deepmerge "^3.2.0"
     hoist-non-react-statics "^3.3.0"
 
-"@draftbit/ui@npm:@samstowers/draftbit-ui":
+"@draftbit/ui@npm:@fancydevpro/draftbit-ui@39.7.1-patch-date-picker-3":
   version "39.7.1-patch-date-picker-3"
-  resolved "https://registry.yarnpkg.com/@samstowers/draftbit-ui/-/draftbit-ui-39.7.1-patch-date-picker-3.tgz#80d96fc8d5d52b72d0f01f10e398a8c2728acf3f"
-  integrity sha512-kByNlUb/dR4UZjMVE0TkkgUrp1BiWaRp2NCqalUxp6mUVBSb5U8Tr7swFKfxiwf74vaHJGKYyXTpalnjfr8Tmw==
+  resolved "https://registry.yarnpkg.com/@fancydevpro/draftbit-ui/-/draftbit-ui-39.7.1-patch-date-picker-3.tgz#b59f94871326e6cf88976ca99a41e22760cbd7bb"
+  integrity sha512-WVvtdqEUdhroo0ZZoxObUmsKYBfJLCbIfVZhh9QpKcTUA3Yk6XPVMKzYkGcODJc3HEtEKQegEQUfY1LdI1TfuA==
   dependencies:
     "@date-io/date-fns" "^1.3.13"
     "@draftbit/react-theme-provider" "^2.1.1"


### PR DESCRIPTION
### What does this PR do?

- Drawn a semi-transparent overlay outside of the date picker.
- Enabled dismissing the date picker by tapping outside.
- Published the forked @draftbit/ui patch version 3 and installed it to the app.

### Context

Ticket: https://www.notion.so/CBT-i-App-Hub-Dozy-c71a8c25d3ec407cbffcd42bd35286f7?p=0be774ba36a04daf963ba1e0c32144e1

### QA checklist

<!-- Some general requirements for QA. If your PR only touches a small self-contained part of the codebase, feel free to only test related components. The depth of testing should match the invasiveness of the PR - add checks accordingly -->

- [x] iOS date picker shows semi-transparent overlay outside.
- [x] Can dismiss the ios picker by tapping outside of it.
- [x] Date picker styles keeps the same.
- [x] Updated date picker version doesn't break the android picker.
