### PR TITLE
Bugfix - Sleep titration module said sleep efficiency increased when it actually decreased

### DIFF
--- a/screens/SRTTitrationScreens.tsx
+++ b/screens/SRTTitrationScreens.tsx
@@ -115,17 +115,17 @@ export const SleepEfficiency = ({ navigation }: Props) => {
     state.userData.baselineInfo.sleepEfficiencyAvg;
 
   function getLabel(sleepEffiencyAvg: number) {
-    if (sleepEffiencyAvg < 80) {
+    if (sleepEfficiencyAvg < sleepEfficiencyAvgBaseline) {
+      return sleepEfficiencyAvg < 85
+        ? `Your sleep efficiency is ok, but with an average of ${sleepEffiencyAvg}% (previously ${sleepEfficiencyAvgBaseline}%) it's not quite where we need it to be yet.`
+        :`Your sleep efficiency was slightly lower ${sleepEffiencyAvg} than your baseline of ${sleepEfficiencyAvgBaseline}%), but it's still plenty high - nothing to worry about.`
+    }
+    else if (sleepEffiencyAvg < 80) {
       return `Your sleep efficiency is ok, but with an average of ${sleepEffiencyAvg}% (previously ${sleepEfficiencyAvgBaseline}%) it's not quite where we need it to be yet.`;
     } else if (sleepEffiencyAvg >= 80 && sleepEffiencyAvg < 87) {
-      return sleepEfficiencyAvg >= sleepEfficiencyAvgBaseline
-        ? `Your sleep is starting to show signs of improvement. You previously had an average sleep efficiency of ${sleepEfficiencyAvgBaseline}%, and it has since been around ${sleepEfficiencyAvg}%! You're making progress!`
-        : `Your sleep is showing signs of improvement. You previously had an average sleep efficiency of ${sleepEfficiencyAvgBaseline}%, and it has since been around ${sleepEfficiencyAvg}%! Keep going!`;
+      return `Your sleep is starting to show signs of improvement. You previously had an average sleep efficiency of ${sleepEfficiencyAvgBaseline}%, and it has since been around ${sleepEfficiencyAvg}%! You're making progress!`
     } else {
-      return sleepEfficiencyAvg >= sleepEfficiencyAvgBaseline
-        ? `Your sleep is showing signs of improvement. You previously had an average sleep efficiency of ${sleepEfficiencyAvgBaseline}%, and it has since risen to ${sleepEfficiencyAvg}%! You're making great progress.`
-        : `Your sleep is showing signs of improvement. You previously had an average sleep efficiency of ${sleepEfficiencyAvgBaseline}%, and it has since been around ${sleepEfficiencyAvg}%! Keep going!`;
-    }
+      return `Your sleep is showing signs of improvement. You previously had an average sleep efficiency of ${sleepEfficiencyAvgBaseline}%, and it has since risen to ${sleepEfficiencyAvg}%! You're making great progress.`    }
   }
 
   return (


### PR DESCRIPTION
### What does this PR do?

- Updated the label in the sleep titration module when the sleep efficiency decreased.

### Context

- https://www.notion.so/CBT-i-App-Hub-Dozy-c71a8c25d3ec407cbffcd42bd35286f7?p=c3557dec1efd42808ee1bb6b7c95fed2
- https://threads.com/34408397900?share=cf461b5c-89b3-4116-8cfc-837cae180e40

### QA checklist

<!-- Some general requirements for QA. If your PR only touches a small self-contained part of the codebase, feel free to only test related components. The depth of testing should match the invasiveness of the PR - add checks accordingly -->

- [x] SRT titration module shows a different label when the average sleep efficiency is between 80% and 87%, but it's decreased.
- [x] SRT titration module shows a different label when the average sleep efficiency is more than 87%, but it's decreased.
- [x] SRT titration module shows the previous label when the sleep efficiency is below 80%.
