### PR TITLE
Bugfix - User in GMT+3 got sleep log reminder 6 hours late

### DIFF
--- a/screens/DiaryScreen.js
+++ b/screens/DiaryScreen.js
@@ -71,7 +71,14 @@ function DiaryScreen() {
             firestore()
               .collection('users')
               .doc(state.userId)
-              .update(encodedTimeData);
+              .update({
+                reminders: {
+                  sleepDiaryReminder: {
+                    diaryReminderTime: encodedTimeData.value,
+                    version: encodedTimeData.version,
+                  },
+                },
+              });
           }
         }
       });


### PR DESCRIPTION
### What does this PR do?

- Migrated existing v0.2 notification data to v0.3 to fix reminder times.
- Fixed updating sleepDiaryReminder data in user data.

### Context

- https://www.notion.so/44bfca24f4f641f699e27f6c2ac4b1d3?v=2b5fe01e830441cfb694bae964a488a1&p=93be3a2fad1a40dcad6ffed2f45736d1
- https://threads.com/34409831437?share=b87a6e06-0959-4c24-a2ca-452ba5245cbe

### QA checklist

<!-- Some general requirements for QA. If your PR only touches a small self-contained part of the codebase, feel free to only test related components. The depth of testing should match the invasiveness of the PR - add checks accordingly -->

- [x] v0.2 notifications are migrated to v0.3 on app startup and it triggers notifications-master update.
- [x] Notification time zones are updated when user's time zone changes.
- [x] user.reminders.sleepDiaryReminder is updated when user's time zone changes.
