### PR TITLE
Bugfix - Bug: Can't create new sleep log after editing then deleting a log

### DIFF
--- a/screens/DiaryEntryScreens.tsx
+++ b/screens/DiaryEntryScreens.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useEffect } from 'react';
 import { Platform, StyleSheet } from 'react-native';
 import { DatePicker } from '@draftbit/ui';
 import { scale } from 'react-native-size-matters';
@@ -137,30 +137,35 @@ export const BedTimeInput: React.FC<Props> = ({ navigation, route }) => {
     (sleepLog) => sleepLog.logId === route.params?.logId,
   );
 
-  // If editing existing sleep log, set defaults from that. Otherwise, use normal defaults
-  if (route.params?.logId) {
-    if (baseSleepLog) {
-      initialDateVal = baseSleepLog.upTime.toDate(); // If editing, use upTime as initial logDate value
+  useEffect((): void => {
+    // If editing existing sleep log, set defaults from that. Otherwise, use normal defaults
+    if (route.params?.logId) {
+      if (baseSleepLog) {
+        initialDateVal = baseSleepLog.upTime.toDate(); // If editing, use upTime as initial logDate value
 
-      logState.logId = route.params.logId;
-      logState.minsToFallAsleep = baseSleepLog.minsToFallAsleep;
-      logState.wakeCount = baseSleepLog.wakeCount;
-      logState.nightMinsAwake = baseSleepLog.nightMinsAwake;
-      logState.SCTNonSleepActivities = baseSleepLog.SCTNonSleepActivities;
-      logState.wakeTime = moment(initialDateVal)
-        .hour(baseSleepLog.wakeTime.toDate().getHours())
-        .minute(baseSleepLog.wakeTime.toDate().getMinutes())
-        .startOf('minute')
-        .toDate();
-      logState.upTime = moment(baseSleepLog.upTime.toDate())
-        .startOf('minute')
-        .toDate();
-      logState.notes = baseSleepLog.notes;
-      logState.tags = baseSleepLog.tags;
+        logState.logId = route.params.logId;
+        logState.minsToFallAsleep = baseSleepLog.minsToFallAsleep;
+        logState.wakeCount = baseSleepLog.wakeCount;
+        logState.nightMinsAwake = baseSleepLog.nightMinsAwake;
+        logState.SCTNonSleepActivities = baseSleepLog.SCTNonSleepActivities;
+        logState.wakeTime = moment(initialDateVal)
+          .hour(baseSleepLog.wakeTime.toDate().getHours())
+          .minute(baseSleepLog.wakeTime.toDate().getMinutes())
+          .startOf('minute')
+          .toDate();
+        logState.upTime = moment(baseSleepLog.upTime.toDate())
+          .startOf('minute')
+          .toDate();
+        logState.notes = baseSleepLog.notes;
+        logState.tags = baseSleepLog.tags;
+      } else {
+        console.error("Attempted to edit sleep log that doesn't exist!");
+      }
     } else {
-      console.error("Attempted to edit sleep log that doesn't exist!");
+      logState.logId = undefined;
     }
-  }
+  }, [route.params?.logId]);
+
   const prevBedtime = baseSleepLog?.bedTime?.toDate();
 
   // Create state to display selected log date


### PR DESCRIPTION
### What does this PR do?

- Fixed the default sleep log data for new sleep log inputs.

### Context

https://www.notion.so/44bfca24f4f641f699e27f6c2ac4b1d3?v=2b5fe01e830441cfb694bae964a488a1&p=e0b696fe293d420caba6d6affdbd342e

### QA checklist

<!-- Some general requirements for QA. If your PR only touches a small self-contained part of the codebase, feel free to only test related components. The depth of testing should match the invasiveness of the PR - add checks accordingly -->

- [x] Logging new sleep data works correctly regardless any previous actions
- [x] The existing updating and deleting keep working correctly
