### PR TITLE
Bugfix - Push notification for support chat messages

### DIFF
--- a/utilities/submitOnboardingData.ts
+++ b/utilities/submitOnboardingData.ts
@@ -264,12 +264,14 @@ export async function submitFirstChatMessage(
       message: "Welcome to Dozy! I'm Sam, I'll be your sleep coach.",
       time: sub(new Date(), { minutes: 4 }),
       sentByUser: false,
+      dontSendNotification: true,
     });
     chatColRef.add({
       sender: coachId,
       message: 'Why do you want to improve your sleep?',
       time: sub(new Date(), { minutes: 3 }),
       sentByUser: false,
+      dontSendNotification: true,
     });
     chatColRef.add({
       sender: displayName ?? 'You',
@@ -283,6 +285,7 @@ export async function submitFirstChatMessage(
         "Thanks for sending! We'll reply soon. You can find our conversation in the Support tab of the app. :)",
       time: new Date(),
       sentByUser: false,
+      dontSendNotification: true,
     };
     chatColRef.add(lastChat);
 


### PR DESCRIPTION
### What does this PR do?

- Prevented to send push notifications for default support chat messages.

### Context

https://www.notion.so/44bfca24f4f641f699e27f6c2ac4b1d3?v=2b5fe01e830441cfb694bae964a488a1&p=18248cfdb3354c1c9ce88257e6fe9858

### QA checklist

<!-- Some general requirements for QA. If your PR only touches a small self-contained part of the codebase, feel free to only test related components. The depth of testing should match the invasiveness of the PR - add checks accordingly -->

- [x] Push notifications are not being sent for the initial 3 support chat messages.
