### PR TITLE
Bugfix - If someone is past the scheduled checkin date, their progress % shows a crazy number

### DIFF
--- a/screens/TreatmentScreen.tsx
+++ b/screens/TreatmentScreen.tsx
@@ -71,12 +71,14 @@ export const TreatmentScreen: React.FC<{ navigation: Navigation }> = ({
     const lastCheckinTime = state.userData.currentTreatments.lastCheckinDatetime
       .toDate()
       .getTime();
-    let progressPercent = ~~(
-      (100 *
-        (nextCheckinTime - lastCheckinTime - (nextCheckinTime - Date.now()))) /
-      (nextCheckinTime - lastCheckinTime)
-    );
-    progressPercent = progressPercent > 100 ? 100 : progressPercent;
+    let progressPercent = ~~(nextCheckinTime > lastCheckinTime
+      ? (100 *
+          (nextCheckinTime -
+            lastCheckinTime -
+            (nextCheckinTime - Date.now()))) /
+        (nextCheckinTime - lastCheckinTime)
+      : 100);
+    progressPercent = Math.min(100, progressPercent);
 
     // Estimate treatment completion date & % progress based on treatmentPlan
     // const estCompletionDate = treatmentPlan[treatmentPlan.length - 1].estDate;


### PR DESCRIPTION
### What does this PR do?

- Fixed negative progress percent in TreatmentScreen.

### Context

https://www.notion.so/44bfca24f4f641f699e27f6c2ac4b1d3?v=2b5fe01e830441cfb694bae964a488a1&p=3881f3ec577e4b0fa380b1e67fa8274f

### QA checklist

<!-- Some general requirements for QA. If your PR only touches a small self-contained part of the codebase, feel free to only test related components. The depth of testing should match the invasiveness of the PR - add checks accordingly -->

- [x] Progress has a valid percentage in range of 0 ~ 100%
