### PR TITLE
Bugfix - App crashes after cancelling time selection, then hitting next

### DIFF
--- a/components/screens/DateTimePickerScreen.tsx
+++ b/components/screens/DateTimePickerScreen.tsx
@@ -161,8 +161,9 @@ const DateTimePickerScreen = (
               format="dddd, mmmm dS"
               date={selectedTime}
               onDateChange={(time: Date) => {
-                setSelectedTime(time);
-                checkDataValidity(time);
+                const newTime = time || selectedTime || new Date();
+                setSelectedTime(newTime);
+                checkDataValidity(newTime);
               }}
             />
             <DatePicker
@@ -176,8 +177,9 @@ const DateTimePickerScreen = (
               format="h:MM TT"
               date={selectedTime}
               onDateChange={(time: Date) => {
-                setSelectedTime(time);
-                checkDataValidity(time);
+                const newTime = time || selectedTime || new Date();
+                setSelectedTime(newTime);
+                checkDataValidity(newTime);
               }}
             />
           </View>
@@ -197,8 +199,9 @@ const DateTimePickerScreen = (
               hitSlop={{ left: 60, top: 40, right: 60, bottom: 40 }}
               date={selectedTime}
               onDateChange={(time: Date) => {
-                setSelectedTime(time);
-                checkDataValidity(time);
+                const newTime = time || selectedTime || new Date();
+                setSelectedTime(newTime);
+                checkDataValidity(newTime);
               }}
             />
           </View>


### PR DESCRIPTION
### What does this PR do?

- Prevented setting invalid times when pressing cancel on android datetimepicker.

### Context

- https://www.notion.so/CBT-i-App-Hub-Dozy-c71a8c25d3ec407cbffcd42bd35286f7?p=3e9edae67773466993b78d4640e2131a

### QA checklist

<!-- Some general requirements for QA. If your PR only touches a small self-contained part of the codebase, feel free to only test related components. The depth of testing should match the invasiveness of the PR - add checks accordingly -->

- [x] Android app doesn't crash when pressing cancel on date time picker
- [x] Cancel button doesn't change date and time on android date time picker
