### PR TITLE
Bugfix - Text box on sleep tags screen displays poorly and inconsistently on iPhone 7

### DIFF
--- a/components/screens/TagSelectScreen.tsx
+++ b/components/screens/TagSelectScreen.tsx
@@ -126,8 +126,8 @@ const TagSelectScreen: React.FC<Props> = ({
       />
       <ScrollView
         contentContainerStyle={styles.container}
-        scrollEnabled={false}
         ref={scrollViewRef}
+        keyboardDismissMode="on-drag"
         onLayout={Platform.OS === 'android' ? onAndroidLayout : undefined}
       >
         <KeyboardAwareView
@@ -227,13 +227,13 @@ const styles = StyleSheet.create({
   },
   View_TextInputContainer: {
     alignSelf: 'stretch',
-    marginTop: 0,
-    marginBottom: '7%',
+    marginTop: scale(12),
+    marginBottom: scale(15),
     borderBottomWidth: 1.5,
   },
   Container_nof: {
     width: '100%',
-    height: '10%',
+    height: '9%',
     justifyContent: 'space-between',
     flexDirection: 'row',
     marginTop: scale(17),
@@ -243,6 +243,7 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     justifyContent: 'space-between',
     alignItems: 'center',
+    paddingTop: scale(10),
   },
   Text_nqt: {
     textAlign: 'center',
@@ -257,10 +258,11 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     alignContent: 'center',
     alignItems: 'flex-start',
+    marginTop: scale(12),
   },
   // eslint-disable-next-line react-native/no-color-literals
   notesInput: {
-    height: scale(35),
+    height: scale(38),
     color: '#ffffff',
     fontSize: scale(17),
     paddingBottom: scale(10),


### PR DESCRIPTION
### What does this PR do?

- Adjusted styles in TagSelectScreen
- Made the tags section scrollable

### Context

https://www.notion.so/44bfca24f4f641f699e27f6c2ac4b1d3?v=2b5fe01e830441cfb694bae964a488a1&p=2fa71154fec04813b3181af4f2e4d0ac

### QA checklist

<!-- Some general requirements for QA. If your PR only touches a small self-contained part of the codebase, feel free to only test related components. The depth of testing should match the invasiveness of the PR - add checks accordingly -->

- [x] The tags section scrolls correctly when keyboard is shown
- [x] The text and placeholder in the notes text input aren't cut off
