### PR TITLE
Bugfix - Would like to be able to send users messages even if they only get partway through onboarding

### DIFF
--- a/screens/OnboardingScreens.tsx
+++ b/screens/OnboardingScreens.tsx
@@ -99,6 +99,19 @@ export const Welcome: React.FC<Props> = ({ navigation }) => {
         coach,
       });
     });
+
+    Notification.registerForPushNotificationsAsync().then(
+      async (expoPushToken) => {
+        if (expoPushToken) {
+          onboardingState.expoPushToken = expoPushToken;
+          const userId = await SecureStore.getItemAsync('userId');
+          if (userId) {
+            Notification.updateExpoPushToken(expoPushToken, userId);
+          }
+        }
+      },
+    );
+
     Analytics.logEvent(AnalyticsEvents.onboardingWelcome);
   }, []);
 
@@ -639,20 +652,6 @@ export const SafetyPillsStop: React.FC<Props> = ({ navigation }) => {
 export const SafetyPillsBye: React.FC<Props> = ({ navigation }) => {
   useEffect((): void => {
     Analytics.logEvent(AnalyticsEvents.onboardingSafetyPillsBye);
-
-    if (onboardingState.expoPushToken === 'No push token provided') {
-      Notification.registerForPushNotificationsAsync().then(
-        async (expoPushToken) => {
-          if (expoPushToken) {
-            onboardingState.expoPushToken = expoPushToken;
-            const userId = await SecureStore.getItemAsync('userId');
-            if (userId) {
-              Notification.updateExpoPushToken(expoPushToken, userId);
-            }
-          }
-        },
-      );
-    }
   }, []);
 
   return (
@@ -900,20 +899,6 @@ export const BaselineIntro: React.FC<Props> = ({ navigation }) => {
 export const BaselineBye: React.FC<Props> = ({ navigation }) => {
   useEffect((): void => {
     Analytics.logEvent(AnalyticsEvents.onboardingBaselineBye);
-
-    if (onboardingState.expoPushToken === 'No push token provided') {
-      Notification.registerForPushNotificationsAsync().then(
-        async (expoPushToken) => {
-          if (expoPushToken) {
-            onboardingState.expoPushToken = expoPushToken;
-            const userId = await SecureStore.getItemAsync('userId');
-            if (userId) {
-              Notification.updateExpoPushToken(expoPushToken, userId);
-            }
-          }
-        },
-      );
-    }
   }, []);
 
   return (
@@ -994,18 +979,8 @@ export const DiaryReminder: React.FC<Props> = ({ navigation }) => {
       bottomBackButton={() => navigation.goBack()}
       defaultValue={moment().hour(9).minute(0).toDate()}
       onQuestionSubmit={(value: Date | boolean) => {
-        // TODO: Can I just make the arrow function async instead of below
-        async function setPushToken() {
-          // TODO: Make less dumb
-          const pushToken =
-            await Notification.registerForPushNotificationsAsync();
-          if (pushToken) {
-            onboardingState.expoPushToken = pushToken;
-          }
-        }
         if (typeof value != 'boolean') {
           onboardingState.diaryReminderTime = value;
-          setPushToken();
           Analytics.logEvent(AnalyticsEvents.onboardingDiaryReminderSet);
         } else {
           Analytics.logEvent(AnalyticsEvents.onboardingDiaryReminderUnset);
@@ -1045,17 +1020,6 @@ export const CheckinScheduling: React.FC<Props> = ({ navigation }) => {
 
   useEffect(() => {
     Analytics.logEvent(AnalyticsEvents.onboardingCheckinScheduling);
-
-    // Ask push notification permission if user didn't allow to set a reminder
-    if (onboardingState.expoPushToken === 'No push token provided') {
-      Notification.registerForPushNotificationsAsync().then(
-        async (expoPushToken) => {
-          if (expoPushToken) {
-            onboardingState.expoPushToken = expoPushToken;
-          }
-        },
-      );
-    }
 
     // Update the default checkin time in case of user left the app in background and returns again
     const handleAppStateChange = (state: AppStateStatus): void => {


### PR DESCRIPTION
### What does this PR do?

- Asked push notification permission at the first step of onboarding and saved it to user's doc

### Context

https://www.notion.so/44bfca24f4f641f699e27f6c2ac4b1d3?v=2b5fe01e830441cfb694bae964a488a1&p=1158b6296ac84365bd93bc40ed703e3f

### QA checklist

<!-- Some general requirements for QA. If your PR only touches a small self-contained part of the codebase, feel free to only test related components. The depth of testing should match the invasiveness of the PR - add checks accordingly -->

- [x] Push notification permission is asked at the first step of onboarding so that user can receive push notifications regardless of onboarding completeness
- [x] Admin can send a message with a push notification once user registered in app
