### PR TITLE
chore: add user sign up date to user document

### DIFF
--- a/utilities/auth.service.ts
+++ b/utilities/auth.service.ts
@@ -87,6 +87,7 @@ export default class Auth {
                       email: result.user.email,
                       uid: result.user.uid,
                       photoURL: result.user.photoURL ?? '',
+                      signUpDate: firestore.FieldValue.serverTimestamp(),
                     },
                     onboardingComplete: false,
                     lastChat: {


### PR DESCRIPTION
### What does this PR do?
- Adds the sign-up date(generated with firebase's timeStamp object) to the user document when it is newly created.
<!-- Please describe your changes in detail -->

### Context

<!-- Please include a link to the relevant Thread, Notion task/document, or any other useful information -->

### QA checklist

<!-- Some general requirements for QA. If your PR only touches a small self-contained part of the codebase, feel free to only test related components. The depth of testing should match the invasiveness of the PR - add checks accordingly -->

- [ ] Newly generated user document has a valid `signUpDate` field.
- [ ] User first time sign-in is not broken.

