### PR TITLE
chore: upgrade build image for eas

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -2,7 +2,7 @@
   "build": {
     "base": {
       "ios": {
-        "image": "macos-big-sur-11.4-xcode-12.5",
+        "image": "macos-big-sur-11.4-xcode-13.0",
         "cocoapods": "1.10.2"
       }
     },


### PR DESCRIPTION
### What does this PR do?
- Upgrades the build image for EAS builds to fix failing builds.
<!-- Please describe your changes in detail -->
- Apple requires a minimum iOS SDK of iOS 15 which can only be found in Xcode 13. This change upgrades the build image to use XCode 13, hence bumping the iOS SDK version.
### Context

<!-- Please include a link to the relevant Thread, Notion task/document, or any other useful information -->

### QA checklist

<!-- Some general requirements for QA. If your PR only touches a small self-contained part of the codebase, feel free to only test related components. The depth of testing should match the invasiveness of the PR - add checks accordingly -->

